### PR TITLE
feat: Update expiration timestamp error

### DIFF
--- a/src/verify.ts
+++ b/src/verify.ts
@@ -153,7 +153,7 @@ export function verifyExpiration(
 ) {
   const expiration = options.expiration ?? DEFAULT_EXPIRATION
   if (timestamp + expiration < Date.now()) {
-    throw new RequestError(`Expired signature`, 401)
+    throw new RequestError(`Expired signature: signature timestamp: ${timestamp}, timestamp expiration: ${expiration + Date.now()}`, 401)
   }
 
   return true

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -152,8 +152,14 @@ export function verifyExpiration(
   options: VerifyAuthChainHeadersOptions = {}
 ) {
   const expiration = options.expiration ?? DEFAULT_EXPIRATION
-  if (timestamp + expiration < Date.now()) {
-    throw new RequestError(`Expired signature: signature timestamp: ${timestamp}, timestamp expiration: ${expiration + Date.now()}`, 401)
+  const now = Date.now()
+  if (timestamp + expiration < now) {
+    throw new RequestError(
+      `Expired signature: signature timestamp: ${timestamp}, timestamp expiration: ${
+        timestamp + expiration
+      }, local timestamp: ${now}`,
+      401
+    )
   }
 
   return true


### PR DESCRIPTION
This PR updates the timestamp expiration message to include the user's timestamp and the timestamp expiration to have a clear understanding of why the request failed.